### PR TITLE
Be more tolerant of unpredictable data returned from Canary

### DIFF
--- a/canary/api.py
+++ b/canary/api.py
@@ -311,13 +311,13 @@ class SensorType(Enum):
 class Entry:
     def __init__(self, data):
         self._entry_id = data["id"]
-        self._description = data["description"]
-        self._entry_type = data["entry_type"]
-        self._start_time = data["start_time"]
-        self._end_time = data["end_time"]
+        self._description = data.get('description','')
+        self._entry_type = data.get('entry_type','')
+        self._start_time = data.get('start_time','')
+        self._end_time = data.get('end_time','')
         self._thumbnails = []
 
-        for thumbnail_data in data["thumbnails"]:
+        for thumbnail_data in data.get('thumbnails',''):
             self._thumbnails.append(Thumbnail(thumbnail_data))
 
     @property


### PR DESCRIPTION
Often these values are unset, leading to `KeyError`s 

```
KeyError: 'description'
ERROR (MainThread) [homeassistant.setup] Unable to setup dependencies of camera.canary. Setup failed for dependencies: canary
```

which will break the entire Canary support when the camera is actually working fine. Instead, just set a default of '' and silently ignore and continue with initialization. By doing this, the component initializes and is available in the UI properly instead of completely failing to load. 