### PR TITLE
Fix canary login

### DIFF
--- a/canary/live_stream_api.py
+++ b/canary/live_stream_api.py
@@ -23,7 +23,7 @@ URL_LIVE_STREAM = "https://my.canary.is/api/watchlive/{device_id}/" \
 
 ATTR_USERNAME = "username"
 ATTR_PASSWORD = "password"
-ATTR_ACCESS_TOKEN = "token"
+ATTR_TOKEN = "token"
 ATTR_SESSION_ID = "sessionId"
 
 class LiveStreamApi:
@@ -58,7 +58,7 @@ class LiveStreamApi:
         })
 
         self._ssesyranac = ssesyranac
-        self._token = response.json()[ATTR_ACCESS_TOKEN]
+        self._token = response.json()[ATTR_TOKEN]
         self._xsrf_token = xsrf_token
         self._csrf_token = csrf_token
 


### PR DESCRIPTION
@snjoetw Please review

Proposed changes:
- Added CSRF token header on requests
- Added CSRF cookie
- Changed body on login to JSON
- Token key in the response body is now `token` instead of `access_token`

Fixes: #4 
Related issue: home-assistant/core#35569