### PR TITLE
Fixes the authentication error on live stream API

### DIFF
--- a/canary/live_stream_api.py
+++ b/canary/live_stream_api.py
@@ -21,7 +21,7 @@ URL_LIVE_STREAM = "https://my.canary.is/api/watchlive/{device_id}/" \
 
 ATTR_USERNAME = "username"
 ATTR_PASSWORD = "password"
-ATTR_ACCESS_TOKEN = "access_token"
+ATTR_ACCESS_TOKEN = "token"
 ATTR_SESSION_ID = "sessionId"
 
 
@@ -42,7 +42,7 @@ class LiveStreamApi:
         xsrf_token = response.cookies[COOKIE_XSRF_TOKEN]
         ssesyranac = response.cookies[COOKIE_SSESYRANAC]
 
-        response = requests.post(URL_LOGIN_API, {
+        response = requests.post(URL_LOGIN_API, json={
             ATTR_USERNAME: self._username,
             ATTR_PASSWORD: self._password
         }, headers={

--- a/tests/fixtures/live_stream_api_login.json
+++ b/tests/fixtures/live_stream_api_login.json
@@ -1,0 +1,6 @@
+{
+  "token": "ffffffffffffffffffffffffffffffffffffffff",
+  "user": {
+    "email": "someuser@someemailserver.com"
+  }
+}

--- a/tests/test_live_stream_api.py
+++ b/tests/test_live_stream_api.py
@@ -1,0 +1,55 @@
+"""The tests for the Canary sensor platform."""
+import os
+import unittest
+
+import requests_mock
+
+from canary.live_stream_api import (
+    LiveStreamApi,
+    URL_LOGIN_API,
+    URL_LOGIN_PAGE,
+    COOKIE_XSRF_TOKEN,
+    COOKIE_SSESYRANAC
+)
+
+COOKIE_XSRF_VAL = "xsrf"
+COOKIE_COOKIE_SSESYRANAC_VAL = "ssesyranac"
+
+
+def load_fixture(filename):
+    """Load a fixture."""
+    path = os.path.join(os.path.dirname(__file__), 'fixtures', filename)
+    with open(path) as fptr:
+        return fptr.read()
+
+
+def _setup_responses(mock):
+    mock.register_uri(
+        "POST",
+        URL_LOGIN_API,
+        text=load_fixture("live_stream_api_login.json"))
+    mock.register_uri(
+        "GET",
+        URL_LOGIN_PAGE,
+        cookies={
+            COOKIE_XSRF_TOKEN: COOKIE_XSRF_VAL,
+            COOKIE_SSESYRANAC: COOKIE_COOKIE_SSESYRANAC_VAL
+        }
+    )
+
+
+class TestLiveStreamApi(unittest.TestCase):
+    @requests_mock.Mocker()
+    def test_login(self, mock):
+        """Test login for canary live stream api"""
+        _setup_responses(mock)
+        api = LiveStreamApi("user", "pass")
+
+        api.login()
+
+        with self.subTest("stores the token on the api object"):
+            self.assertEqual(api._token,
+                             "ffffffffffffffffffffffffffffffffffffffff")
+
+        with self.subTest("stores ssesyranac cookie on the api object"):
+            self.assertEqual(api._ssesyranac, "ssesyranac")


### PR DESCRIPTION
This commit is a minimal commit, and changes only that which is absolutely
required to get the login to work again.

Closes #4