### PR TITLE
fix: Fix for Missing Temperature Readings and also a fix for pytest runs and for video streaming

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+max-line-length = 88
+select = B,C,E,F,W,T4,B9
+# ignore = E203, E266, E501, W503, F403, F401

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,3 +24,15 @@ repos:
     rev: 4.0.1
     hooks:
     -   id: flake8
+-   repo: local
+    hooks:
+      # Run mypy through our wrapper script in order to get the possible
+      # pyenv and/or virtualenv activated; it may not have been e.g. if
+      # committing from a GUI tool that was not launched from an activated
+      # shell.
+    -   id: pylint
+        name: pylint
+        entry: script/run-in-env.sh pylint -j 0
+        language: script
+        types: [python]
+        files: ^canary/.+\.py$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.2.0
+    hooks:
+    -   id: check-yaml
+    -   id: check-ast
+    -   id: check-merge-conflict
+    -   id: debug-statements
+    -   id: detect-private-key
+    -   id: end-of-file-fixer
+    -   id: requirements-txt-fixer
+    -   id: trailing-whitespace
+        exclude: ^tests/fixtures/
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v2.32.1
+    hooks:
+    -   id: pyupgrade
+        args: [--py36-plus]
+-   repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+    -   id: black
+-   repo: https://github.com/PyCQA/flake8
+    rev: 4.0.1
+    hooks:
+    -   id: flake8

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # py-canary [![Build Status](https://travis-ci.org/snjoetw/py-canary.svg?branch=master)](https://travis-ci.org/snjoetw/py-canary)
 Python API for Canary Security Camera.  This is used in [Home Assistant](https://home-assistant.io) but should be generic enough that can be used elsewhere.
+
+## TAG 0.5.2.B1
+- Fixes: Temperature readings are now returned for Canary Pro
+- Fixes: Live Streaming from Canary Pro and Canary Flex.  Canary View is untested, but _should_ work too
+- drops the range for getting readings from 2 hours to 40 minutes to allow the Canary API to return data for the possible 5 sensor type readings
+- updates canary's user agent header app version and iOS version to current values
+
+
+### Development changes
+- pytest now works with the changes to the live stream api changes
+- adds pre-commit (dev tool)
+- adds pytest config data

--- a/canary/api.py
+++ b/canary/api.py
@@ -108,7 +108,7 @@ class Api:
 
     def get_readings(self, device_id):
         end = datetime.utcnow()
-        start = end - timedelta(hours=1)
+        start = end - timedelta(minutes=40)
         created_range = (
             f"{start.strftime(DATETIME_FORMAT)},{end.strftime(DATETIME_FORMAT)}"
         )

--- a/canary/api.py
+++ b/canary/api.py
@@ -9,12 +9,12 @@ from canary.live_stream_api import LiveStreamApi, LiveStreamSession
 HEADER_AUTHORIZATION = "Authorization"
 HEADER_USER_AGENT = "User-Agent"
 
-HEADER_VALUE_AUTHORIZATION = "Bearer {}"
-HEADER_VALUE_USER_AGENT = "Canary/2.10.0 (iPhone; iOS 11.2; Scale/3.00)"
+HEADER_VALUE_AUTHORIZATION = "Bearer"
+HEADER_VALUE_USER_AGENT = "Canary/5.9.0 (iPhone; iOS 15.4.1; Scale/3.00)"
 
 URL_LOGIN_API = "https://api.canaryis.com/o/access_token/"
 URL_LOCATIONS_API = "https://api.canaryis.com/v1/locations/"
-URL_LOCATION_API = "https://api.canaryis.com/v1/locations/{}/"
+URL_LOCATION_API = "https://api.canaryis.com/v1/locations/"
 URL_MODES_API = "https://api.canaryis.com/v1/modes/"
 URL_ENTRIES_API = "https://api.canaryis.com/v1/entries/"
 URL_READINGS_API = "https://api.canaryis.com/v1/readings/"
@@ -59,19 +59,23 @@ class Api:
         self.login()
 
     def login(self):
-        response = requests.post(URL_LOGIN_API, {
-            ATTR_USERNAME: self._username,
-            ATTR_PASSWORD: self._password,
-            ATTR_CLIENT_ID: ATTR_VALUE_CLIENT_ID,
-            ATTR_CLIENT_SECRET: ATTR_VALUE_CLIENT_SECRET,
-            ATTR_GRANT_TYPE: ATTR_VALUE_GRANT_TYPE,
-            ATTR_SCOPE: ATTR_VALUE_SCOPE,
-        }, timeout=self._timeout, headers={
-            HEADER_USER_AGENT: HEADER_VALUE_USER_AGENT
-        })
+        response = requests.post(
+            URL_LOGIN_API,
+            {
+                ATTR_USERNAME: self._username,
+                ATTR_PASSWORD: self._password,
+                ATTR_CLIENT_ID: ATTR_VALUE_CLIENT_ID,
+                ATTR_CLIENT_SECRET: ATTR_VALUE_CLIENT_SECRET,
+                ATTR_GRANT_TYPE: ATTR_VALUE_GRANT_TYPE,
+                ATTR_SCOPE: ATTR_VALUE_SCOPE,
+            },
+            timeout=self._timeout,
+            headers={HEADER_USER_AGENT: HEADER_VALUE_USER_AGENT},
+        )
 
-        _LOGGER.debug("Received login response: %s, %s", response.status_code,
-                      response.content)
+        _LOGGER.debug(
+            f"Received login response: {response.status_code}, {response.content}"
+        )
 
         response.raise_for_status()
 
@@ -87,28 +91,37 @@ class Api:
         return [Location(data, self._modes_by_name) for data in json]
 
     def get_location(self, location_id):
-        url = URL_LOCATION_API.format(location_id)
+        url = f"{URL_LOCATION_API}{location_id}/"
         json = self._call_api("get", url).json()
         return Location(json, self._modes_by_name)
 
     def set_location_mode(self, location_id, mode_name, is_private=False):
-        url = URL_LOCATION_API.format(location_id)
-        self._call_api("patch", url, json={
-            "mode": self._modes_by_name[mode_name].resource_uri,
-            "is_private": is_private
-        })
+        url = f"{URL_LOCATION_API}{location_id}/"
+        self._call_api(
+            "patch",
+            url,
+            json={
+                "mode": self._modes_by_name[mode_name].resource_uri,
+                "is_private": is_private,
+            },
+        )
 
     def get_readings(self, device_id):
         end = datetime.utcnow()
         start = end - timedelta(hours=1)
-        created_range = "{},{}".format(start.strftime(DATETIME_FORMAT),
-                                       end.strftime(DATETIME_FORMAT))
-        json = self._call_api("get", URL_READINGS_API, {
-            "created__range": created_range,
-            "device": device_id,
-            "resolution": "10m",
-            "limit": 0
-        }).json()["objects"]
+        created_range = (
+            f"{start.strftime(DATETIME_FORMAT)},{end.strftime(DATETIME_FORMAT)}"
+        )
+        json = self._call_api(
+            "get",
+            URL_READINGS_API,
+            {
+                "created__range": created_range,
+                "device": device_id,
+                "resolution": "10m",
+                "limit": 0,
+            },
+        ).json()["objects"]
         return [Reading(data) for data in json]
 
     def get_latest_readings(self, device_id):
@@ -121,37 +134,48 @@ class Api:
 
         return readings_by_type.values()
 
-    def get_entries(self, location_id, entry_type="motion", limit=1,
-                    last_modified=None):
+    def get_entries(
+        self, location_id, entry_type="motion", limit=1, last_modified=None
+    ):
         if last_modified is None:
             last_modified = datetime.utcnow() - timedelta(days=3)
 
-        json = self._call_api("get", URL_ENTRIES_API, {
-            "last_modified__gt": last_modified.strftime(DATETIME_FORMAT),
-            "include_deleted": "True",
-            "offset": "0",
-            "location": location_id,
-            "limit": limit,
-            "entry_type": entry_type,
-        }).json()["objects"]
+        json = self._call_api(
+            "get",
+            URL_ENTRIES_API,
+            {
+                "last_modified__gt": last_modified.strftime(DATETIME_FORMAT),
+                "include_deleted": "True",
+                "offset": "0",
+                "location": location_id,
+                "limit": limit,
+                "entry_type": entry_type,
+            },
+        ).json()["objects"]
         return [Entry(data) for data in json]
 
     def get_live_stream_session(self, device):
         if self._live_stream_api is None:
-            self._live_stream_api = LiveStreamApi(self._username,
-                                                  self._password,
-                                                  self._timeout)
+            self._live_stream_api = LiveStreamApi(
+                self._username, self._password, self._timeout
+            )
         return LiveStreamSession(self._live_stream_api, device)
 
     def _call_api(self, method, url, params=None, **kwargs):
-        _LOGGER.debug("About to call %s with %s", url, params)
+        _LOGGER.debug(f"About to call {url} with {params}")
 
-        response = requests.request(method, url, params=params,
-                                    timeout=self._timeout,
-                                    headers=self._api_headers(), **kwargs)
+        response = requests.request(
+            method,
+            url,
+            params=params,
+            timeout=self._timeout,
+            headers=self._api_headers(),
+            **kwargs,
+        )
 
-        _LOGGER.debug("Received API response: %s, %s", response.status_code,
-                      response.content)
+        _LOGGER.debug(
+            f"Received API response: {response.status_code}, {response.content}"
+        )
 
         response.raise_for_status()
 
@@ -160,8 +184,7 @@ class Api:
     def _api_headers(self):
         return {
             HEADER_USER_AGENT: HEADER_VALUE_USER_AGENT,
-            HEADER_AUTHORIZATION: HEADER_VALUE_AUTHORIZATION.format(
-                self._token)
+            HEADER_AUTHORIZATION: f"{HEADER_VALUE_AUTHORIZATION} {self._token}",
         }
 
 
@@ -312,13 +335,13 @@ class SensorType(Enum):
 class Entry:
     def __init__(self, data):
         self._entry_id = data["id"]
-        self._description = data.get('description', '')
-        self._entry_type = data.get('entry_type', '')
-        self._start_time = data.get('start_time', '')
-        self._end_time = data.get('end_time', '')
+        self._description = data.get("description", "")
+        self._entry_type = data.get("entry_type", "")
+        self._start_time = data.get("start_time", "")
+        self._end_time = data.get("end_time", "")
         self._thumbnails = []
 
-        for thumbnail_data in data.get('thumbnails', []):
+        for thumbnail_data in data.get("thumbnails", []):
             self._thumbnails.append(Thumbnail(thumbnail_data))
 
     @property
@@ -362,7 +385,7 @@ class Mode:
         self._resource_uri = data["resource_uri"]
 
     def __repr__(self):
-        return "Mode(id={}, name={})".format(self.mode_id, self.name)
+        return f"Mode(id={self.mode_id}, name={self.name})"
 
     @property
     def mode_id(self):

--- a/canary/api.py
+++ b/canary/api.py
@@ -100,7 +100,7 @@ class Api:
 
     def get_readings(self, device_id):
         end = datetime.utcnow()
-        start = end - timedelta(hours=2)
+        start = end - timedelta(hours=1)
         created_range = "{},{}".format(start.strftime(DATETIME_FORMAT),
                                        end.strftime(DATETIME_FORMAT))
         json = self._call_api("get", URL_READINGS_API, {

--- a/canary/live_stream_api.py
+++ b/canary/live_stream_api.py
@@ -12,7 +12,7 @@ HEADER_AUTHORIZATION = "Authorization"
 
 HEADER_VALUE_AUTHORIZATION = "Bearer {}"
 
-URL_LOGIN_PAGE = "https://my.canary.is/v2/login"
+URL_LOGIN_PAGE = "https://my.canary.is/manifest.json"
 URL_LOGIN_API = "https://api-prod.canaryis.com/o/access_token/"
 URL_START_SESSION = "https://my.canary.is/api/watchlive/{device_uuid}/session"
 URL_RENEW_SESSION = "https://my.canary.is/api/watchlive/{device_uuid}/send"

--- a/canary/live_stream_api.py
+++ b/canary/live_stream_api.py
@@ -4,20 +4,14 @@ from requests import HTTPError
 COOKIE_XSRF_TOKEN = "XSRF-TOKEN"
 COOKIE_SSESYRANAC = "ssesyranac"
 
-COOKIE_VALUE_SSESYRANAC = "token={}"
-
 HEADER_XSRF_TOKEN = "X-XSRF-TOKEN"
-HEADER_SSESYRANAC = "ssesyranac"
 HEADER_AUTHORIZATION = "Authorization"
 
-HEADER_VALUE_AUTHORIZATION = "Bearer {}"
+HEADER_VALUE_AUTHORIZATION = "Bearer"
 
 URL_LOGIN_PAGE = "https://my.canary.is/manifest.json"
 URL_LOGIN_API = "https://api-prod.canaryis.com/o/access_token/"
-URL_START_SESSION = "https://my.canary.is/api/watchlive/{device_uuid}/session"
-URL_RENEW_SESSION = "https://my.canary.is/api/watchlive/{device_uuid}/send"
-URL_LIVE_STREAM = "https://my.canary.is/api/watchlive/{device_id}/" \
-                  "{session_id}/stream.m3u8"
+URL_WATCHLIVE_BASE = "https://my.canary.is/api/watchlive/"
 
 ATTR_USERNAME = "username"
 ATTR_PASSWORD = "password"
@@ -30,6 +24,7 @@ ATTR_SCOPE = "scope"
 ATTR_VALUE_CLIENT_ID = "53e67d00de5638b3d8f7"
 ATTR_VALUE_GRANT_TYPE = "password"
 ATTR_VALUE_SCOPE = "write"
+
 
 class LiveStreamApi:
     def __init__(self, username, password, timeout=10):
@@ -48,18 +43,21 @@ class LiveStreamApi:
         xsrf_token = response.cookies[COOKIE_XSRF_TOKEN]
         ssesyranac = response.cookies[COOKIE_SSESYRANAC]
 
-        response = requests.post(URL_LOGIN_API, {
-            ATTR_USERNAME: self._username,
-            ATTR_PASSWORD: self._password,
-            ATTR_CLIENT_ID: ATTR_VALUE_CLIENT_ID,
-            ATTR_GRANT_TYPE: ATTR_VALUE_GRANT_TYPE,
-            ATTR_SCOPE: ATTR_VALUE_SCOPE
-        }, headers={
-            HEADER_XSRF_TOKEN: xsrf_token
-        }, cookies={
-            COOKIE_XSRF_TOKEN: xsrf_token,
-            COOKIE_SSESYRANAC: ssesyranac
-        })
+        response = requests.post(
+            URL_LOGIN_API,
+            {
+                ATTR_USERNAME: self._username,
+                ATTR_PASSWORD: self._password,
+                ATTR_CLIENT_ID: ATTR_VALUE_CLIENT_ID,
+                ATTR_GRANT_TYPE: ATTR_VALUE_GRANT_TYPE,
+                ATTR_SCOPE: ATTR_VALUE_SCOPE,
+            },
+            headers={HEADER_XSRF_TOKEN: xsrf_token},
+            cookies={
+                COOKIE_XSRF_TOKEN: xsrf_token,
+                COOKIE_SSESYRANAC: ssesyranac,
+            },
+        )
 
         self._ssesyranac = ssesyranac
         self._token = response.json()[ATTR_TOKEN]
@@ -67,12 +65,11 @@ class LiveStreamApi:
 
     def start_session(self, device_uuid):
         response = requests.post(
-            URL_START_SESSION.format(device_uuid=device_uuid),
+            f"{URL_WATCHLIVE_BASE}{device_uuid}/session",
             headers=self._api_headers(),
             cookies=self._api_cookies(),
-            json={
-                "deviceUUID": device_uuid
-            })
+            json={"deviceUUID": device_uuid},
+        )
         response.raise_for_status()
 
         session_id = response.json().get(ATTR_SESSION_ID)
@@ -84,12 +81,11 @@ class LiveStreamApi:
 
     def renew_session(self, device_uuid, session_id):
         response = requests.post(
-            URL_RENEW_SESSION.format(device_uuid=device_uuid),
+            f"{URL_WATCHLIVE_BASE}{device_uuid}/send",
             headers=self._api_headers(),
             cookies=self._api_cookies(),
-            json={
-                ATTR_SESSION_ID: session_id
-            })
+            json={ATTR_SESSION_ID: session_id},
+        )
         response.raise_for_status()
 
         json = response.json()
@@ -97,20 +93,18 @@ class LiveStreamApi:
         return "message" in json and json["message"] == "success"
 
     def get_live_stream_url(self, device_id, session_id):
-        return URL_LIVE_STREAM.format(device_id=device_id,
-                                      session_id=session_id)
+        return f"{URL_WATCHLIVE_BASE}{device_id}/{session_id}/stream.m3u8"
 
     def _api_cookies(self):
         return {
             COOKIE_XSRF_TOKEN: self._xsrf_token,
-            COOKIE_SSESYRANAC: self._ssesyranac
+            COOKIE_SSESYRANAC: self._ssesyranac,
         }
 
     def _api_headers(self):
         return {
             HEADER_XSRF_TOKEN: self._xsrf_token,
-            HEADER_AUTHORIZATION: HEADER_VALUE_AUTHORIZATION.format(
-                self._token)
+            HEADER_AUTHORIZATION: f"{HEADER_VALUE_AUTHORIZATION} {self._token}",
         }
 
 
@@ -130,8 +124,7 @@ class LiveStreamSession:
                 self._api.renew_session(self._device_uuid, self._session_id)
             except HTTPError as ex:
                 if ex.response.status_code == 403:
-                    self._session_id = self._api.start_session(
-                        self._device_uuid)
+                    self._session_id = self._api.start_session(self._device_uuid)
                 else:
                     raise ex
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,10 +2,8 @@
 line-length = 88
 
 [tool.pytest.ini_options]
-log_cli = true
-log_cli_level = "INFO"
-log_cli_format = "%(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)"
-log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+log_format = "%(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)"
+log_date_format = "%Y-%m-%d %H:%M:%S"
 testpaths = [
     "tests",
     ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[tool.black]
+line-length = 88
+
+[tool.pytest.ini_options]
+log_cli = true
+log_cli_level = "INFO"
+log_cli_format = "%(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+testpaths = [
+    "tests",
+    ]
+markers = [
+    "slow: mark test as slow (deselect with '-m \"not slow\"')",
+    "current_test: marks the current coding test to run",
+    "unfinished: test is currently being coded (deselect with '-m \"not unfinished\"')"
+    ]

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -1,6 +1,7 @@
 coveralls
 flake8
 mock
+pre-commit
 pylint
 pytest
 pytest-cov

--- a/script/run-in-env.sh
+++ b/script/run-in-env.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env sh
+set -eu
+
+# Activate pyenv and virtualenv if present, then run the specified command
+
+# pyenv, pyenv-virtualenv
+if [ -s .python-version ]; then
+    PYENV_VERSION=$(head -n 1 .python-version)
+    export PYENV_VERSION
+fi
+
+# other common virtualenvs
+my_path=$(git rev-parse --show-toplevel)
+
+for venv in venv .venv .; do
+  if [ -f "${my_path}/${venv}/bin/activate" ]; then
+    . "${my_path}/${venv}/bin/activate"
+    break
+  fi
+done
+
+exec "$@"

--- a/tests/fixtures/live_stream_api_login.json
+++ b/tests/fixtures/live_stream_api_login.json
@@ -1,5 +1,5 @@
 {
-  "token": "ffffffffffffffffffffffffffffffffffffffff",
+  "access_token": "ffffffffffffffffffffffffffffffffffffffff",
   "user": {
     "email": "someuser@someemailserver.com"
   }

--- a/tests/test_live_stream_api.py
+++ b/tests/test_live_stream_api.py
@@ -10,7 +10,6 @@ from canary.live_stream_api import (
     URL_LOGIN_PAGE,
     COOKIE_XSRF_TOKEN,
     COOKIE_SSESYRANAC,
-    COOKIE_CNRYCSRF
 )
 
 COOKIE_XSRF_VAL = "xsrf"
@@ -36,7 +35,6 @@ def _setup_responses(mock):
         cookies={
             COOKIE_XSRF_TOKEN: COOKIE_XSRF_VAL,
             COOKIE_SSESYRANAC: COOKIE_COOKIE_SSESYRANAC_VAL,
-            COOKIE_CNRYCSRF: COOKIE_CNRYCSRF_VAL,
         }
     )
 


### PR DESCRIPTION
Not sure how data was returned in the past, but it appears that Canary has changed the number of records returned by Readings API URL or changed the sort order, but on April 30th, 2022 the temperature readings were no longer returned from the get_readings function.

Manually calling the API calls in PAW showed that the readings API call returns 20 records, with the first 12 being air_quality, the next 8 being humidity.  Changing the created__range to 1 hour at 10 minute intervals returns 19 records( 1-6 being air quality, 7-12 humidity, 13-18 temperature and 19 being wifi) with all records listed in descending time.

Also fixed is running pytest after Katie made changes for fixing Live Streaming.

[Home Assistant issue thread](https://github.com/home-assistant/core/issues/71052)
[Temperature is no longer being returned in the get_readings / get_latest_readings call ](https://github.com/snjoetw/py-canary/issues/12)